### PR TITLE
Fix #10921

### DIFF
--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -1,3 +1,4 @@
+{{- if not (and (eq .Values.controller.kind "DaemonSet") .Values.controller.daemonset.useHostPort) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -72,3 +73,4 @@ spec:
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.service.type }}"
+{{- end }}


### PR DESCRIPTION
When the controller kind is specified as DaemonSet and useHostPort is set to true, there is no need to spin up a service of type NodePort or LoadBalancer, or at least you should be able to disable this option.